### PR TITLE
TRITON-2114 Fix sdc-hermes breakage introduced back in AGENT-1089

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ ACTOR_JS_FILES = \
 	lib/cmd.js \
 	lib/conn.js \
 	lib/findstream.js \
+        lib/listglob.js \
 	lib/logsets.js \
 	lib/remember.js \
 	lib/worker.js

--- a/actor/lib/listglob.js
+++ b/actor/lib/listglob.js
@@ -16,8 +16,6 @@ var mod_child = require('child_process');
 var mod_verror = require('verror');
 var mod_assert = require('assert-plus');
 
-var LS = '/usr/bin/ls';
-
 function list_glob(pattern, callback) {
 	mod_assert.string(pattern, 'pattern');
 	mod_assert.func(callback, 'callback');

--- a/actor/lib/worker.js
+++ b/actor/lib/worker.js
@@ -336,7 +336,7 @@ _disp()
 			do_delete: _delete
 		}, 'archiving log file');
 
-		self._manta_upload(inf, manta_path, _delete, function (err) {
+		self._manta_upload(inf, manta_path, _delete, _upload, function (err) {
 			if (err) {
 				self.lsw_log.error({
 					err: err


### PR DESCRIPTION
The fixes have been verified through testing of the sdc-sdc LAB-516 branch image in Eng staging, which has deps/hermes updated to includes the fixes in this PR. The logsets upload to manta works as expected.